### PR TITLE
feat(gpu): EKS MIG WEIGHTED_GPU_UTIL operator 연동 — 이미지 핀 4.5.3-4.8.2 + csv.go 동기화 (KAZAA-537)

### DIFF
--- a/internal/controller/install_agents.go
+++ b/internal/controller/install_agents.go
@@ -874,7 +874,7 @@ func addDcgmExporterToNodeAgent(podSpec *corev1.PodSpec, cr *monitoringv2alpha1.
 	gpuSpec := cr.Spec.Features.K8sAgent.GpuMonitoring
 
 	// Check if a custom image is specified
-	dcgmImage := "public.ecr.aws/whatap/dcgm-exporter:4.4.2-4.7.13-ubuntu22.04"
+	dcgmImage := "public.ecr.aws/whatap/dcgm-exporter:4.5.3-4.8.2-ubuntu22.04"
 	if gpuSpec.CustomImageFullName != "" {
 		dcgmImage = gpuSpec.CustomImageFullName
 	}

--- a/internal/gpu/csv.go
+++ b/internal/gpu/csv.go
@@ -35,6 +35,7 @@ const WhatapGPUMetricsCSV = `
 
     # Utilization
     DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).                     # code 203
+    DCGM_FI_DEV_WEIGHTED_GPU_UTIL, gauge, Weighted GPU utilization for MIG and non-MIG devices (ratio 0.0-1.0). # code 9003
     #DCGM_FI_DEV_MEM_COPY_UTIL, gauge, Memory copy engine utilization (in %).      # code 204
     #DCGM_FI_DEV_ENC_UTIL,      gauge, Encoder utilization (in %).                 # code 206
     #DCGM_FI_DEV_DEC_UTIL,      gauge, Decoder utilization (in %).                 # code 207


### PR DESCRIPTION
## 배경
dcgm-exporter PR #3(https://github.com/whatap/dcgm-exporter/pull/3)로 추가된 신규 게이지 `DCGM_FI_DEV_WEIGHTED_GPU_UTIL`(code 9003, ratio 0.0–1.0)을 whatap-operator(EKS MIG dcgm-exporter 배포)에 연동. 관련: KAZAA-537 (원이슈 KAZAA-534, 리뷰 KAZAA-536, 이미지 배포 KAZAA-535).

## 변경
### 1. (필수) dcgm-exporter 기본 이미지 핀 교체 — `internal/controller/install_agents.go`
- `public.ecr.aws/whatap/dcgm-exporter:4.4.2-4.7.13-ubuntu22.04` → `:4.5.3-4.8.2-ubuntu22.04`
- 신규 태그는 KAZAA-535가 WEIGHTED 포함(PR #3 squash `6eecc16` cherry-pick)으로 ECR Public에 배포한 산출물(2026-06-15, linux/amd64).
- `CustomImageFullName` override 경로는 변경 없음(기본값만 교체).

### 2. (저우선) csv.go 동기화 — `internal/gpu/csv.go`
- allowlist에 `DCGM_FI_DEV_WEIGHTED_GPU_UTIL` 추가 → `manifests/resources.yaml`과 정의 일치.
- 기능 영향 없음: dcgm-exporter는 `rendermetrics.RenderGroup`에서 metrics 맵 전체를 CSV 필터 없이 렌더하고 `WeightedUtil` 트랜스포머가 무조건 등록되므로 CSV 등재 여부와 무관하게 `/metrics`에 노출됨. 문서/일관성 목적.

## 검증
- `go build ./internal/controller/ ./internal/gpu/` PASS
- `go vet ./internal/controller/ ./internal/gpu/` PASS
- ECR Public 태그 존재/pull 가능 독립 확인: registry API `GET …/manifests/4.5.3-4.8.2-ubuntu22.04` → HTTP 200, linux/amd64 매니페스트 포함 OCI 이미지 인덱스.

## 잔여 (별도 추적)
- EKS MIG(A100) 런타임 실검증(메트릭 값 확인)은 A100 MIG 클러스터 필요 → KAZAA-537에서 후속 처리.

🤖 Generated with [Claude Code](https://claude.com/claude-code)