### PR TITLE
[KAZAA-641] Java/Python/Node.js ENV 주입 시 타 솔루션 충돌 ENV override 수정

### DIFF
--- a/internal/webhook/v2alpha1/injector_env_test.go
+++ b/internal/webhook/v2alpha1/injector_env_test.go
@@ -1,0 +1,148 @@
+package v2alpha1
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/go-logr/logr"
+	monitoringv2alpha1 "github.com/whatap/whatap-operator/api/v2alpha1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// envValues returns every value bound to name (in order). Kubernetes applies the FIRST one;
+// a correct injection must therefore leave exactly one entry with the operator value.
+func envValues(envs []corev1.EnvVar, name string) []string {
+	var out []string
+	for _, e := range envs {
+		if e.Name == name {
+			out = append(out, e.Value)
+		}
+	}
+	return out
+}
+
+// effective returns the value Kubernetes would apply for name (first occurrence).
+func effective(envs []corev1.EnvVar, name string) (string, bool) {
+	for _, e := range envs {
+		if e.Name == name {
+			return e.Value, true
+		}
+	}
+	return "", false
+}
+
+func TestUpsertEnvVars_DropsStaleDuplicate(t *testing.T) {
+	base := []corev1.EnvVar{
+		{Name: "whatap.server.host", Value: "127.0.0.1"}, // injected earlier by a 3rd-party webhook
+		{Name: "KEEP", Value: "yes"},
+	}
+	got := upsertEnvVars(base, []corev1.EnvVar{{Name: "whatap.server.host", Value: "10.0.0.1"}})
+
+	if vals := envValues(got, "whatap.server.host"); len(vals) != 1 || vals[0] != "10.0.0.1" {
+		t.Fatalf("expected single host=10.0.0.1, got %v", vals)
+	}
+	if v, _ := effective(got, "KEEP"); v != "yes" {
+		t.Fatalf("unrelated env KEEP was lost: %v", got)
+	}
+	// base must not be mutated
+	if base[0].Value != "127.0.0.1" {
+		t.Fatalf("upsertEnvVars mutated base: %v", base)
+	}
+}
+
+// The core KAZAA-641 regression: a 3rd-party webhook put whatap.server.host=127.0.0.1 at the
+// FRONT of container.Env. The operator value must still win (single, correct entry).
+func TestInjectJavaEnvVars_OverridesPreInjectedHost(t *testing.T) {
+	container := corev1.Container{
+		Name: "app",
+		Env: []corev1.EnvVar{
+			{Name: EnvJavaWhatapHost, Value: "127.0.0.1"}, // stale conflict, first → would normally win
+			{Name: EnvJavaToolOptions, Value: "-Dexisting=1"},
+		},
+	}
+	target := monitoringv2alpha1.TargetSpec{
+		Envs: []corev1.EnvVar{{Name: EnvWhatapHost, Value: "10.20.30.40"}}, // user/CR override
+	}
+
+	got := injectJavaEnvVars(container, target, monitoringv2alpha1.WhatapAgent{}, logr.Discard())
+
+	if vals := envValues(got, EnvJavaWhatapHost); len(vals) != 1 || vals[0] != "10.20.30.40" {
+		t.Fatalf("expected single whatap.server.host=10.20.30.40, got %v", vals)
+	}
+	// JAVA_TOOL_OPTIONS must be preserved and augmented with the -javaagent option, not overridden.
+	v, ok := effective(got, EnvJavaToolOptions)
+	if !ok || !strings.Contains(v, "-Dexisting=1") || !strings.Contains(v, ValJavaAgentOptionPrefix) {
+		t.Fatalf("JAVA_TOOL_OPTIONS not preserved+augmented: %q", v)
+	}
+}
+
+func TestInjectPythonEnvVars_OverridesPreInjectedHostAndKeepsPythonPath(t *testing.T) {
+	container := corev1.Container{
+		Name: "app",
+		Env: []corev1.EnvVar{
+			{Name: EnvPythonWhatapHost, Value: "127.0.0.1"}, // stale conflict
+			{Name: EnvPythonPath, Value: "/app/libs"},       // user value must be preserved
+		},
+	}
+	target := monitoringv2alpha1.TargetSpec{
+		Envs: []corev1.EnvVar{{Name: EnvWhatapHost, Value: "10.20.30.40"}},
+	}
+
+	got := injectPythonEnvVars(container, target, monitoringv2alpha1.WhatapAgent{}, "latest", logr.Discard())
+
+	if vals := envValues(got, EnvPythonWhatapHost); len(vals) != 1 || vals[0] != "10.20.30.40" {
+		t.Fatalf("expected single whatap_server_host=10.20.30.40, got %v", vals)
+	}
+	if v, _ := effective(got, EnvPythonPath); v != "/app/libs" {
+		t.Fatalf("user PYTHONPATH not preserved, got %q", v)
+	}
+}
+
+func TestInjectNodejsEnvVars_OverridesPreInjectedHostAndKeepsNodeOptions(t *testing.T) {
+	container := corev1.Container{
+		Name: "app",
+		Env: []corev1.EnvVar{
+			{Name: EnvNodejsWhatapHost, Value: "127.0.0.1"},
+			{Name: EnvNodejsOptions, Value: "--max-old-space-size=512"}, // user value preserved
+		},
+	}
+	target := monitoringv2alpha1.TargetSpec{
+		Envs: []corev1.EnvVar{{Name: EnvWhatapHost, Value: "10.20.30.40"}},
+	}
+
+	got := injectNodejsEnvVars(container, target, monitoringv2alpha1.WhatapAgent{}, "latest", logr.Discard())
+
+	if vals := envValues(got, EnvNodejsWhatapHost); len(vals) != 1 || vals[0] != "10.20.30.40" {
+		t.Fatalf("expected single WHATAP_SERVER_HOST=10.20.30.40, got %v", vals)
+	}
+	if v, _ := effective(got, EnvNodejsOptions); v != "--max-old-space-size=512" {
+		t.Fatalf("user NODE_OPTIONS not preserved, got %q", v)
+	}
+}
+
+// End-to-end at the assembly point: a stale whatap.name left by another webhook must be
+// overridden by the user's CR target.Envs value, and the operator host must still win.
+func TestInjectLanguageSpecific_UserEnvOverridesStaleAndHostWins(t *testing.T) {
+	container := corev1.Container{
+		Name: "app",
+		Env: []corev1.EnvVar{
+			{Name: "whatap.name", Value: "wrong-auto-name"}, // 3rd-party stale value
+			{Name: EnvJavaWhatapHost, Value: "127.0.0.1"},   // 3rd-party stale value
+		},
+	}
+	target := monitoringv2alpha1.TargetSpec{
+		Envs: []corev1.EnvVar{
+			{Name: "whatap.name", Value: "my-service"}, // user CR override (operator does not manage this key)
+			{Name: EnvWhatapHost, Value: "10.20.30.40"},
+		},
+	}
+
+	got := injectLanguageSpecificEnvVars(container, target, monitoringv2alpha1.WhatapAgent{}, "java", "latest", logr.Discard())
+
+	if vals := envValues(got, "whatap.name"); len(vals) != 1 || vals[0] != "my-service" {
+		t.Fatalf("expected single whatap.name=my-service, got %v", vals)
+	}
+	if vals := envValues(got, EnvJavaWhatapHost); len(vals) != 1 || vals[0] != "10.20.30.40" {
+		t.Fatalf("expected single whatap.server.host=10.20.30.40, got %v", vals)
+	}
+}

--- a/internal/webhook/v2alpha1/injector_java.go
+++ b/internal/webhook/v2alpha1/injector_java.go
@@ -53,7 +53,11 @@ func injectJavaEnvVars(container corev1.Container, target monitoringv2alpha1.Tar
 		{Name: EnvPodName, ValueFrom: &corev1.EnvVarSource{FieldRef: &corev1.ObjectFieldSelector{FieldPath: "metadata.name"}}},
 	}
 
-	return append(envVars, javaEnvVars...)
+	// 와탭이 소유하는 연결/설정 ENV(license, whatap.server.host/port, micro, downward-API)는
+	// 기존 container.Env에 같은 키가 있어도(예: 타 솔루션 webhook이 먼저 주입한 값) operator 값으로 강제 override.
+	// 단순 append는 k8s 중복 규칙(첫 번째 값 우선)에 의해 무시되어 whatap.server.host가 127.0.0.1로 폴백한다(KAZAA-641).
+	// JAVA_TOOL_OPTIONS / WHATAP_JAVA_AGENT_PATH는 override 대상이 아니므로(append/preserve) envVars에 그대로 둔다.
+	return upsertEnvVars(envVars, javaEnvVars)
 }
 
 func injectJavaToolOptions(envVars []corev1.EnvVar, agentOption string, logger logr.Logger) []corev1.EnvVar {

--- a/internal/webhook/v2alpha1/injector_nodejs.go
+++ b/internal/webhook/v2alpha1/injector_nodejs.go
@@ -78,7 +78,12 @@ func injectNodejsEnvVars(container corev1.Container, target monitoringv2alpha1.T
 		}
 	}
 
-	return append(container.Env, envVars...)
+	// 와탭 소유 연결/설정 ENV는 기존 동일 키가 있어도 operator 값으로 강제 override (KAZAA-641, Java/Python과 동일 패턴).
+	// app_name/NODE_PATH/NODE_OPTIONS/agent path 등은 기존/사용자 값을 보존한다.
+	return combineEnvVars(container.Env, envVars, func(name string) bool {
+		_, ok := nodejsForceEnvNames[name]
+		return ok
+	})
 }
 
 // NODEJS_PATH 안전하게 주입 (Python의 injectPythonPath와 동일 패턴)

--- a/internal/webhook/v2alpha1/injector_python.go
+++ b/internal/webhook/v2alpha1/injector_python.go
@@ -78,7 +78,13 @@ func injectPythonEnvVars(container corev1.Container, target monitoringv2alpha1.T
 		}
 	}
 
-	return append(container.Env, envVars...)
+	// 와탭 소유 연결/설정 ENV(license, whatap_server_host/port, WHATAP_HOME, micro, downward-API)는
+	// 기존 container.Env에 동일 키가 있어도 operator 값으로 강제 override (KAZAA-641, 단순 append는 k8s
+	// 중복 첫-값-우선 규칙에 무시됨). app_name/PYTHONPATH/agent path 등은 기존/사용자 값을 보존한다.
+	return combineEnvVars(container.Env, envVars, func(name string) bool {
+		_, ok := pythonForceEnvNames[name]
+		return ok
+	})
 }
 
 // PYTHONPATH 안전하게 주입 (OpenTelemetry 방식)

--- a/internal/webhook/v2alpha1/process_deployments.go
+++ b/internal/webhook/v2alpha1/process_deployments.go
@@ -176,9 +176,14 @@ func injectLanguageSpecificEnvVars(container corev1.Container, target monitoring
 		// For now, if not specialized, just return original + basic
 		envs = container.Env
 	}
-	// Merge user-specified target envs without overriding existing ones
+	// 사용자가 CR(target.Envs)로 명시한 값은 파드에 이미 있던 충돌 값(예: 타 솔루션이 남긴 whatap.name)을
+	// override 한다(KAZAA-641). 단 operator가 직접 관리하는 키(연결정보/agent path/*_OPTIONS 등)는 operator
+	// 값이 우선이며, 그 키들의 정식 override 경로는 getWhatap*EnvVar(WHATAP_HOST 등)이다.
 	if len(target.Envs) > 0 {
-		envs = mergeEnvVars(envs, target.Envs)
+		envs = combineEnvVars(envs, target.Envs, func(name string) bool {
+			_, managed := operatorManagedEnvNames[name]
+			return !managed
+		})
 	}
 	return envs
 }

--- a/internal/webhook/v2alpha1/utils.go
+++ b/internal/webhook/v2alpha1/utils.go
@@ -78,6 +78,103 @@ func mergeEnvVars(base []corev1.EnvVar, extras []corev1.EnvVar) []corev1.EnvVar 
 	return base
 }
 
+// upsertEnvVars overlays overrides onto base BY NAME, forcing the override value to win.
+//
+// For every override entry, ALL pre-existing entries in base with the same name are
+// dropped and the override is appended once. This matters because Kubernetes resolves a
+// duplicated env name to its FIRST occurrence: if another mutating webhook / 3rd-party APM
+// injected e.g. "whatap.server.host" earlier in container.Env, a plain append (operator
+// value last) would be shadowed and the agent would fall back to 127.0.0.1. mergeEnvVars
+// (existing-wins) is therefore insufficient for whatap-owned keys — use this instead.
+//
+// A new slice is returned; base is not mutated. Use only for keys the operator owns and
+// must control (license / server host+port / micro / downward-API metadata). Keys where a
+// user value should be preserved (e.g. PYTHONPATH, agent paths, app name) must keep
+// mergeEnvVars / append semantics.
+func upsertEnvVars(base []corev1.EnvVar, overrides []corev1.EnvVar) []corev1.EnvVar {
+	overrideNames := make(map[string]struct{}, len(overrides))
+	for _, o := range overrides {
+		if o.Name != "" {
+			overrideNames[o.Name] = struct{}{}
+		}
+	}
+	result := make([]corev1.EnvVar, 0, len(base)+len(overrides))
+	for _, e := range base {
+		if _, ok := overrideNames[e.Name]; ok {
+			continue // drop stale duplicate; operator value re-appended below
+		}
+		result = append(result, e)
+	}
+	for _, o := range overrides {
+		if o.Name == "" {
+			continue
+		}
+		result = append(result, o)
+	}
+	return result
+}
+
+// combineEnvVars merges incoming env vars onto base with a per-name policy:
+//   - if force(name) is true  -> upsert semantics: incoming value REPLACES any pre-existing
+//     duplicate in base (operator/CR value wins).
+//   - if force(name) is false -> merge semantics: incoming value is added only if the name is
+//     not already present (a pre-existing/user value is preserved).
+//
+// This lets a single pass force whatap-owned connection keys while preserving keys the
+// operator only augments (PYTHONPATH/NODE_PATH/NODE_OPTIONS) or that the user owns (app name).
+func combineEnvVars(base []corev1.EnvVar, incoming []corev1.EnvVar, force func(name string) bool) []corev1.EnvVar {
+	var forced, additive []corev1.EnvVar
+	for _, e := range incoming {
+		if e.Name != "" && force(e.Name) {
+			forced = append(forced, e)
+		} else {
+			additive = append(additive, e)
+		}
+	}
+	return mergeEnvVars(upsertEnvVars(base, forced), additive)
+}
+
+// toNameSet builds a set from the given names, deduping aliases (e.g. EnvJavaLicense and
+// EnvPythonLicense both resolve to "license").
+func toNameSet(names ...string) map[string]struct{} {
+	set := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		set[n] = struct{}{}
+	}
+	return set
+}
+
+// pythonForceEnvNames / nodejsForceEnvNames are the whatap-owned connection/config keys that
+// the operator must force onto the pod even if another webhook injected a duplicate earlier.
+// App-info keys (app_name/app_process_name/OKIND), search-path keys (PYTHONPATH/NODE_PATH/
+// NODE_OPTIONS) and the agent-path keys are intentionally NOT here: those preserve an
+// existing/user value (the operator only adds or prepends them).
+var (
+	pythonForceEnvNames = toNameSet(
+		EnvPythonLicense, EnvPythonWhatapHost, EnvPythonWhatapPort,
+		EnvWhatapHome, EnvWhatapMicroEnabled,
+		EnvNodeIP, EnvNodeName, EnvPodName,
+	)
+	nodejsForceEnvNames = toNameSet(
+		EnvNodejsLicense, EnvNodejsWhatapHost, EnvNodejsWhatapPort,
+		EnvWhatapHome, EnvWhatapMicroEnabled,
+		EnvNodeIP, EnvNodeName, EnvPodName,
+	)
+)
+
+// operatorManagedEnvNames is every env name the operator itself produces. User CR target.Envs
+// values are allowed to override pre-existing pod duplicates for any OTHER name (e.g. a stale
+// whatap.name another webhook left behind), but for these managed names the operator's own
+// value is authoritative — the supported override path for them is getWhatap*EnvVar.
+var operatorManagedEnvNames = toNameSet(
+	EnvWhatapLicense, EnvWhatapHost, EnvWhatapPort,
+	EnvNodeIP, EnvNodeName, EnvPodName, EnvWhatapMicroEnabled,
+	EnvJavaLicense, EnvJavaWhatapHost, EnvJavaWhatapPort, EnvJavaAgentPath, EnvJavaToolOptions,
+	EnvPythonLicense, EnvPythonWhatapHost, EnvPythonWhatapPort, EnvPythonAgentPath, EnvWhatapHome, EnvPythonPath,
+	EnvAppName, EnvAppProcessName, EnvOkind,
+	EnvNodejsLicense, EnvNodejsWhatapHost, EnvNodejsWhatapPort, EnvNodejsAgentPath, EnvNodejsOptions, EnvNodejsPath,
+)
+
 // matchesSelector checks if the given labels match the selector
 func matchesSelector(labels map[string]string, selector monitoringv2alpha1.PodSelector) bool {
 	// Check matchLabels


### PR DESCRIPTION
## 배경 (KAZAA-641)
타 솔루션(예: 타사 APM javaagent) mutating webhook이 `container.Env` 앞쪽에 `whatap.server.host` 등 충돌 ENV를 먼저 주입하면, operator가 올바른 값을 **뒤에 append** 해도 **k8s 중복 규칙(같은 이름이면 첫 번째 값 적용)** 에 의해 무시된다. 결과적으로 agent가 `whatap.server.host`를 `127.0.0.1`로, `whatap.name`을 auto-naming으로 인식. (SK하이닉스 ask-k8s-team 문의)

## 근본 원인
- `injector_java.go` / `injector_python.go` / `injector_nodejs.go` 모두 whatap 연결/설정 ENV를 `append(container.Env, ...)` 로 **무조건 뒤에 추가**. 기존 동일 키 중복 검사 없음(`WHATAP_JAVA_AGENT_PATH`만 검사).
- 안전한 `mergeEnvVars`(기존 우선)는 있으나, 타사가 먼저 넣은 잘못된 값이 남으므로 **기존 우선 머지로는 부족** → whatap 키는 **강제 override** 필요.

## 변경 (`internal/webhook/v2alpha1`)
- `utils.go`
  - `upsertEnvVars(base, overrides)`: override 키의 기존 중복을 **모두 제거 후 operator 값 재주입**(첫-값-우선 규칙에서도 operator 값이 유일 → 보장). base 비변경(새 슬라이스 반환).
  - `combineEnvVars(base, incoming, force)`: 키별 정책 — `force(name)`이면 override, 아니면 기존 보존(append-if-absent). 연결 키는 강제, `PYTHONPATH`/`NODE_PATH`/`NODE_OPTIONS`/`app_name`/agent path는 보존.
  - `pythonForceEnvNames` / `nodejsForceEnvNames` / `operatorManagedEnvNames` 정의.
- `injector_java.go`: `append` → `upsertEnvVars(envVars, javaEnvVars)`. `JAVA_TOOL_OPTIONS`/`WHATAP_JAVA_AGENT_PATH`는 기존 로직대로 보존.
- `injector_python.go` / `injector_nodejs.go`: `append` → `combineEnvVars(...)` 로 연결/설정 키만 강제 override, 나머지(앱/경로/옵션)는 보존.
- `process_deployments.go` 조립부: CR `target.Envs`가 **파드에 이미 있던 충돌 값(예: 타 솔루션이 남긴 `whatap.name`)을 override**. 단 operator 관리 키는 operator 값이 우선이고, 그 키들의 정식 override 경로는 `getWhatap*EnvVar`(`WHATAP_HOST` 등).

### 우선순위 정책 (정리)
연결/설정 키: **CR target.Envs(getWhatap*EnvVar) = operator 값 > 타 솔루션이 남긴 container.Env 중복값**
operator 비관리 키(예: whatap.name): **CR target.Envs > 파드 기존값**

## 검증
- `go build ./...` / `go vet ./internal/webhook/v2alpha1/` / `gofmt -l` clean
- `go test ./internal/webhook/v2alpha1/` — `injector_env_test.go` 추가:
  - 선주입 `whatap.server.host=127.0.0.1` → operator/CR 값으로 단일 override (java/python/nodejs)
  - `JAVA_TOOL_OPTIONS` / `PYTHONPATH` / `NODE_OPTIONS` 사용자 값 보존
  - 조립부: 타사가 남긴 `whatap.name` 을 CR 값으로 override + host 정상 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)