### PR TITLE
feat(gpu): add XID errors / clock throttle reasons to default dcgm-exporter CSV (KUBER-1286)

### DIFF
--- a/internal/gpu/csv.go
+++ b/internal/gpu/csv.go
@@ -33,6 +33,10 @@ const WhatapGPUMetricsCSV = `
     # Temperature
     DCGM_FI_DEV_GPU_TEMP,    gauge, GPU temperature (in C).                       # code 150
 
+    # Errors & Throttling
+    DCGM_FI_DEV_XID_ERRORS,             gauge, Value of the last XID error encountered.      # code 230
+    DCGM_FI_DEV_CLOCK_THROTTLE_REASONS, gauge, Current clock throttle reasons (bitmask).     # code 240
+
     # Utilization
     DCGM_FI_DEV_GPU_UTIL,      gauge, GPU utilization (in %).                     # code 203
     DCGM_FI_DEV_WEIGHTED_GPU_UTIL, gauge, Weighted GPU utilization for MIG and non-MIG devices (ratio 0.0-1.0). # code 9003


### PR DESCRIPTION
## 배경 (KUBER-1286)

GPU 오픈 메트릭 알림 **기본 템플릿 5종**(프론트 구현 스펙, KUBER-1286)이 참조하는 DCGM 메트릭 중 2개가 operator 기본 CSV allowlist(`internal/gpu/csv.go`)에 없어, **operator `gpuMonitoring` 기본 설치 환경에서는 해당 템플릿 2종에 데이터가 유입되지 않는다**:

| 템플릿 | 메트릭 | 기본 CSV |
|---|---|---|
| gpu_xid_critical | `DCGM_FI_DEV_XID_ERRORS` (code 230) | ❌ 없음 → **추가** |
| gpu_hw_throttle | `DCGM_FI_DEV_CLOCK_THROTTLE_REASONS` (code 240) | ❌ 없음 → **추가** |
| gpu_temp_sustained | `DCGM_FI_DEV_GPU_TEMP` | ✅ 기존 |
| gpu_ecc_dbe | `DCGM_FI_DEV_ECC_DBE_AGG_TOTAL` | ✅ 기존 |
| gpu_underutilized | `DCGM_FI_DEV_WEIGHTED_GPU_UTIL` | ✅ 기존 |

CSV는 `DCGM_EXPORTER_COLLECTORS` env로 강제되고 ConfigMap(`dcgm-exporter-csv`)이 reconcile마다 CreateOrUpdate로 복원되므로, 고객이 ConfigMap을 직접 수정해도 유지되지 않음 → 기본 CSV 수정이 유일한 경로.

## 변경

- `internal/gpu/csv.go`: `# Errors & Throttling` 섹션 신설, 위 2개 필드 추가 (gauge, GPU당 1 시계열 — 수집 비용 증가 미미)

## 영향/호환성

- openagent 스크랩은 `__name__ =~ DCGM.*` keep이라 추가 설정 없이 그대로 유입됨
- 기존 메트릭·라벨 변경 없음 (순수 추가), dcgm-exporter 이미지 핀(4.5.3-4.8.2-ubuntu22.04) 변경 없음
- `DCGM_FI_DEV_XID_ERRORS`는 NVIDIA 기본 counters CSV에도 포함된 표준 필드, `CLOCK_THROTTLE_REASONS`는 비트마스크 gauge

## 검증

- `go build ./internal/...` OK
- `go test ./internal/gpu/... ./internal/controller/...` OK (기존 테스트 전부 통과, CSV 내용을 assert하는 테스트 없음)

🤖 Generated with [Claude Code](https://claude.com/claude-code)