### PR TITLE
[KAZAA-3046] kube java 에이전트 힙 사이징 정책 개선 — Xms=Xmx 45% 고정 커밋 재설계

### DIFF
--- a/manifests/resources.yaml
+++ b/manifests/resources.yaml
@@ -198,7 +198,12 @@ data:
     fi
 
     heapsize=$(echo "0.45 $WHATAP_MEM_LIMIT" | awk '{print int($1 * $2 / 1048576)}')
-    JAVA_OPTS="-Xms${heapsize}m -Xmx${heapsize}m"
+    # 초기 힙은 최대 힙의 1/4만 커밋한다 — Xms=Xmx 고정 선할당은 live heap(실측 44~57MB)의
+    # 3배가 넘는 RSS를 상시 점유해 OOMKilled 여유를 없앤다 (KAZAA-3046)
+    heapinit=$((heapsize / 4)); if [ "$heapinit" -lt 16 ]; then heapinit=16; fi
+    JAVA_OPTS="-Xms${heapinit}m -Xmx${heapsize}m"
+    JAVA_OPTS="$JAVA_OPTS -XX:MinHeapFreeRatio=15 -XX:MaxHeapFreeRatio=40 -XX:G1PeriodicGCInterval=900000"
+    JAVA_OPTS="$JAVA_OPTS -XX:MaxMetaspaceSize=96m -XX:ReservedCodeCacheSize=64m"
     JAVA_OPTS="$JAVA_OPTS -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ExitOnOutOfMemoryError -XshowSettings:vm"
     JAVA_OPTS="$JAVA_OPTS -Dwhatap.home=/whatap_conf"
 
@@ -249,7 +254,12 @@ data:
     EOL
 
     heapsize=$(echo "0.45 $WHATAP_MEM_LIMIT" | awk '{print int($1 * $2 / 1048576)}')
-    JAVA_OPTS="-Xms${heapsize}m -Xmx${heapsize}m"
+    # 초기 힙은 최대 힙의 1/4만 커밋한다 — Xms=Xmx 고정 선할당은 live heap(실측 44~57MB)의
+    # 3배가 넘는 RSS를 상시 점유해 OOMKilled 여유를 없앤다 (KAZAA-3046)
+    heapinit=$((heapsize / 4)); if [ "$heapinit" -lt 16 ]; then heapinit=16; fi
+    JAVA_OPTS="-Xms${heapinit}m -Xmx${heapsize}m"
+    JAVA_OPTS="$JAVA_OPTS -XX:MinHeapFreeRatio=15 -XX:MaxHeapFreeRatio=40 -XX:G1PeriodicGCInterval=900000"
+    JAVA_OPTS="$JAVA_OPTS -XX:MaxMetaspaceSize=96m -XX:ReservedCodeCacheSize=64m"
     JAVA_OPTS="$JAVA_OPTS -XX:+UseG1GC -XX:+UseStringDeduplication -XX:+ExitOnOutOfMemoryError -XshowSettings:vm"
     JAVA_OPTS="$JAVA_OPTS -Dwhatap.home=/whatap_conf"
 


### PR DESCRIPTION
## 배경 (KAZAA-3046 / KAZAA-2959 타깃 1)

KAZAA-2959 메모리 프로파일 실측 결론: master/node java 에이전트의 "메모리 사용률 ~83%"는 누수가 아니라 **entrypoint.sh의 `Xms=Xmx=limit×45%` 고정 선할당** 구조가 원인.

- full GC 후 live heap **44~57MB**에 불과한데 heap committed **157MB**(=0.45×350Mi)가 통째로 RSS에 상주
- non-heap ~130MB(metaspace 31MB + codecache 22MB + 스레드 72개 + netty 4MB) 합산 시 VmHWM이 limit-16~27MB까지 도달 — 스파이크 여유 없음, 과거 OOMKilled 실증(exitCode 137, restartCount 5)
- 이번 A/B 실측에서도 **현행 플래그의 node agent가 기동 직후 VmHWM 345MB(350Mi limit의 96%)** 를 찍는 것을 재확인

## 변경 내용 (JVM 기동 정책만 — 수집/emit 로직 무변경)

`manifests/resources.yaml`의 master/node entrypoint 2곳, 동일 패턴:

| 항목 | 변경 전 | 변경 후 | 근거 |
|---|---|---|---|
| Xmx | 0.45×limit | **유지** (0.45×limit) | 힙 수요는 클러스터 규모 비례. 기존 limit 사이징 가이드(45% 전제) 호환, 대형 클러스터 안전판 유지 |
| Xms | =Xmx (고정 커밋) | **Xmx/4 (최소 16m)** | live heap 실측 44~57MB 대비 157MB 선점이 과대. 초기 커밋을 낮춰 실사용만 점유 |
| HeapFreeRatio | (기본 40/70) | **Min 15 / Max 40** | G1 수축(uncommit) 허용 폭 — committed ≈ live×1.2~1.7로 수렴 |
| G1PeriodicGCInterval | 없음 | **900000 (15분)** | young GC만 도는 워크로드에선 수축 계기가 없음 → 주기적 concurrent cycle로 반환 강제 (JEP 346) |
| MaxMetaspaceSize | 무제한 | **96m** | 42일 러닝 실사용 31MB의 3배. 진단 불가능한 OOMKilled 대신 진단 가능한 OOME로 전환 |
| ReservedCodeCacheSize | 기본 240m | **64m** | 실사용 22MB의 3배. reserved라 RSS 절감은 없고 상한 하이진 |

- 스레드 72개 스택 비용(-Xss)은 이번 범위 아님 — 별도 이슈 후보.
- 같은 정책이 helm 차트(whatap/helm)에도 있어 동일 변경 PR 별도 제출: https://github.com/whatap/helm/pull/2
- 콘솔 생성 kube.yaml(서버측)은 머지 후 별도 전달 필요.

## dgx-llm A/B 실측 (kube_mon:1.9.15, 프로덕션 동일 리소스 200m/350Mi, 부하: shinhan-demo ~50TPS 병행 수집)

heap-a(현행) / heap-b(개선) 스택을 같은 클러스터에 병행 배포, 30초 간격 VmRSS/VmHWM 70분 + 양쪽 JFR 60분.

68분 시계열(30초 간격 101샘플, 단위 MiB, limit 350MiB):

| 대상 | RSS p50 | 후반30분 평균 | RSS max | VmHWM | HWM 여유 | HWM/limit |
|---|---|---|---|---|---|---|
| master A(현행) | 288.4 | 291.6 | 298.5 | 310.9 | 39.1 | 88.8% |
| **master B(개선)** | **222.4** | **230.1** | 254.8 | **268.0** | **82.0** | **76.6%** |
| node A(현행) | 272.1 | 273.9 | 302.4 | 337.2 | **12.8** | **96.3%** |
| **node B(개선)** | **214.5** | **228.5** | 266.6 | **280.1** | **69.9** | **80.0%** |

- **ΔRSS(p50): master -66.0MiB(-22.9%), node -57.6MiB(-21.2%)** — 기대효과(-80~110MB RSS)는 full GC 후 기준 달성(아래)
- workingSet 스팟(35분, kubelet stats): master 277.5→207.0(-70.5), node 263.1→184.3(-78.8)

**full GC 후 (65분 시점, jattach `GC.run`→`GC.heap_info`):**

| | live heap | heap committed | VmRSS |
|---|---|---|---|
| A(현행) | 45.8 | **158.0** | 291.4 |
| B(개선) | 45.1 | **70.0** | **198.7** |

- live heap 양쪽 동일(~46MiB, KAZAA-2959 실측 44~57MB와 일치) → 개선 플래그가 수집 워크로드에 영향 없음
- **heap committed -88MiB, full GC 후 RSS -92.7MiB(-31.8%)**

**GC pause (JFR 60분, KAZAA-2959 기준선: 합계 0.57%, 중앙값 82.6ms):**

| | pause 횟수 | 합계 | 60분 대비 | 중앙값 | p99 | 최대 | Full GC |
|---|---|---|---|---|---|---|---|
| A(현행) | 614 (young 398 + remark/cleanup 216) | 42.5s | 1.18% | 15.5ms | 761ms | 1310ms | 0 |
| B(개선) | 1166 (young 774 + remark/cleanup 392) | 64.9s | 1.80% | 10.6ms | 608ms | 1110ms | 0 |

- 예상대로 pause **횟수 +90%**, 합계 +0.62pp — 단 개별 pause는 젊은 영역 축소로 **더 짧아짐**(중앙값 -4.9ms, p99 -153ms, 최대 -200ms). Full GC 0건.
- 합계 1.80%는 여전히 낮은 수준(200m CPU 하). KAZAA-2959 기준선(0.57%/중앙값 82.6ms)은 42d uptime 프로덕션 창이라 직접 비교 부적합 — 동일 조건 A/B 상호 비교가 공정하며, 같은 창에서 A도 1.18%였음(기동 초기 + 평문 캡처 부하 포함).

**OOMKilled 재발 방지 관점:**

- 현행(A): node VmHWM **337.2/350MiB = 96.3%(여유 12.8MiB)**, master 88.8%(여유 39.1MiB). 프로덕션 master(43d, 재시작 2.8h 후)도 92.4% — 스파이크 여유 사실상 없음, 과거 OOMKilled(exitCode 137)와 정합.
- 개선(B): node **80.0%(여유 69.9MiB)**, master **76.6%(여유 82.0MiB)** — HWM-limit 마진이 node 5.5배, master 2.1배로 확대. `-XX:+ExitOnOutOfMemoryError`+Metaspace 상한으로 힙 계열 이상은 진단 가능한 OOME 경로로 유도.

## emit 패리티 게이트 (KAZAA-2960 하네스, 머지 게이트)

baseline `/var/tmp/emit-parity/baselines/kube_mon-1.9.15-20260715/a.jsonl` 대비 heap-b(개선 플래그) 캡처 diff:

**게이트 판정 = 동일 윈도 A/B 직접 비교: `PASS (FAIL 0 / WARN 4)`** — report-ha-vs-hb.md

| 비교 | 판정 | 의미 |
|---|---|---|
| **ha(현행 플래그) vs hb(개선 플래그)** — 같은 68분 윈도, 유일 변수=JVM 플래그 | **PASS (FAIL 0 / WARN 4)** | **플래그 변경이 emit 스트림에 무영향** (WARN 4건은 transient 파드 manifest 1건 값차이·container_id 평균비교 등 판정 무관 노이즈) |
| baseline(07-15) vs ha(현행 플래그) — 대조군 | FAIL 65 / WARN 243 | 어제→오늘 클러스터 환경 드리프트 |
| baseline(07-15) vs hb(개선 플래그) | FAIL 65 / WARN 243 | 위와 **FAIL 항목 집합 완전 동일**(pack 카운트 미세차만) |

baseline 대비 FAIL 65건은 두 비교에서 **완전히 동일한 집합**으로, 07-15 baseline 캡처 이후 클러스터에 생긴 변화(istio 신규 배포로 인한 `security.istio.io/*` 태그, 호스트 재부팅·본 실측 스택 배포가 만든 kube_event 타입 변화, HPA 신규 등장 등) — 즉 **현행 플래그(ha)로도 똑같이 FAIL**하는 환경 요인이며 본 변경과 무관함을 대조군으로 실증. 캡처 원본(546K packs, decode error 0)과 리포트 3종은 dgx `/var/tmp/heap-ab-3046/` 아카이브.

## 호환성/영향

- CR/CRD/RBAC 변경 없음. ConfigMap 스크립트 텍스트만 변경.
- 기존 설치는 ConfigMap 재적용(helm upgrade 또는 resources.yaml 재적용) + 파드 재시작 시 반영.
- Java 17 전제 플래그(G1PeriodicGCInterval은 JDK 12+) — kube_mon 이미지는 openjdk17-jre-headless 고정이라 충족.

관련: KAZAA-3046 (KAZAA-2959 타깃 1)
