### PR TITLE
chore(gpu): update DCGM exporter and hostengine defaults

### DIFF
--- a/examples/whatap-agent-all-options.yaml
+++ b/examples/whatap-agent-all-options.yaml
@@ -273,7 +273,7 @@ spec:
         # 물리 GPU + MIG GPU Instance 메트릭을 동시에 수집할 때 필요합니다.
         # hostEngine:
         #   enabled: true
-        #   # customImageFullName: "nvidia/dcgm:4.4.1-2-ubuntu22.04"
+        #   # customImageFullName: "nvcr.io/nvidia/cloud-native/dcgm:4.6.0-1-ubuntu24.04"
         #   # port: 5555
 
         # GPU 메트릭에 대한 MetricRelabelConfigs (옵션)

--- a/internal/controller/install_agents.go
+++ b/internal/controller/install_agents.go
@@ -874,7 +874,7 @@ func addDcgmExporterToNodeAgent(podSpec *corev1.PodSpec, cr *monitoringv2alpha1.
 	gpuSpec := cr.Spec.Features.K8sAgent.GpuMonitoring
 
 	// Check if a custom image is specified
-	dcgmImage := "public.ecr.aws/whatap/dcgm-exporter:4.5.3-4.8.2-ubuntu22.04"
+	dcgmImage := "public.ecr.aws/whatap/dcgm-exporter:4.6.0-4.8.3-distroless"
 	if gpuSpec.CustomImageFullName != "" {
 		dcgmImage = gpuSpec.CustomImageFullName
 	}
@@ -978,7 +978,7 @@ func addDcgmExporterToNodeAgent(podSpec *corev1.PodSpec, cr *monitoringv2alpha1.
 
 	// Add DCGM host engine sidecar container if enabled
 	if gpuSpec.HostEngine != nil && gpuSpec.HostEngine.Enabled {
-		hostEngineImage := "nvidia/dcgm:4.4.1-2-ubuntu22.04"
+		hostEngineImage := "nvcr.io/nvidia/cloud-native/dcgm:4.6.0-1-ubuntu24.04"
 		if gpuSpec.HostEngine.CustomImageFullName != "" {
 			hostEngineImage = gpuSpec.HostEngine.CustomImageFullName
 		}

--- a/internal/controller/install_agents_test.go
+++ b/internal/controller/install_agents_test.go
@@ -194,3 +194,59 @@ func TestAddDcgmExporterToNodeAgent_ClusterNameEnv(t *testing.T) {
 		t.Fatalf("expected DCGM_EXPORTER_KUBERNETES_CLUSTER_NAME env var to be present")
 	}
 }
+
+func TestAddDcgmExporterToNodeAgent_DefaultImagesWithHostEngine(t *testing.T) {
+	cr := &monitoringv2alpha1.WhatapAgent{
+		Spec: monitoringv2alpha1.WhatapAgentSpec{
+			Features: monitoringv2alpha1.FeaturesSpec{
+				K8sAgent: monitoringv2alpha1.K8sAgentSpec{
+					GpuMonitoring: monitoringv2alpha1.GpuMonitoringSpec{
+						Enabled: true,
+						HostEngine: &monitoringv2alpha1.DcgmHostEngineSpec{
+							Enabled: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	podSpec := corev1.PodSpec{}
+	addDcgmExporterToNodeAgent(&podSpec, cr)
+
+	if len(podSpec.Containers) != 2 {
+		t.Fatalf("expected dcgm-exporter and dcgm-hostengine containers, got %d", len(podSpec.Containers))
+	}
+
+	containers := make(map[string]corev1.Container, len(podSpec.Containers))
+	for _, container := range podSpec.Containers {
+		containers[container.Name] = container
+	}
+
+	exporter, ok := containers["dcgm-exporter"]
+	if !ok {
+		t.Fatal("expected dcgm-exporter container")
+	}
+	if exporter.Image != "public.ecr.aws/whatap/dcgm-exporter:4.6.0-4.8.3-distroless" {
+		t.Fatalf("unexpected default dcgm-exporter image: %s", exporter.Image)
+	}
+
+	hostEngine, ok := containers["dcgm-hostengine"]
+	if !ok {
+		t.Fatal("expected dcgm-hostengine container")
+	}
+	if hostEngine.Image != "nvcr.io/nvidia/cloud-native/dcgm:4.6.0-1-ubuntu24.04" {
+		t.Fatalf("unexpected default dcgm-hostengine image: %s", hostEngine.Image)
+	}
+
+	remoteHostEngine := ""
+	for _, env := range exporter.Env {
+		if env.Name == "DCGM_REMOTE_HOSTENGINE_INFO" {
+			remoteHostEngine = env.Value
+			break
+		}
+	}
+	if remoteHostEngine != "localhost:5555" {
+		t.Fatalf("expected exporter to connect to localhost:5555, got %q", remoteHostEngine)
+	}
+}


### PR DESCRIPTION
## Summary
- default dcgm-exporter to `public.ecr.aws/whatap/dcgm-exporter:4.6.0-4.8.3-distroless`
- default hostengine to `nvcr.io/nvidia/cloud-native/dcgm:4.6.0-1-ubuntu24.04`
- verify hostEngine mode creates `dcgm-exporter` + `dcgm-hostengine` and wires `localhost:5555`
- update the all-options example

## Why
The legacy WhaTap 4.4.2 build contained a fork-only 30-second GPU topology watcher and reproduced 160 mixed-MIG errors in five minutes on dgx-a100. The new WhaTap exporter is NVIDIA upstream 4.6.0-4.8.3 plus `DCGM_FI_DEV_WEIGHTED_GPU_UTIL` only.

## Verification
- new default-image regression test: RED on old defaults, GREEN on new defaults
- controller/internal/webhook unit packages: PASS
- full `go test ./...` reached only the existing cluster E2E suite and stopped because the generic Go container has no kubectl/cluster.