### PR TITLE
fix(gpu): allow embedded exporter with hostengine sidecar

### DIFF
--- a/internal/controller/install_agents.go
+++ b/internal/controller/install_agents.go
@@ -941,6 +941,19 @@ func addDcgmExporterToNodeAgent(podSpec *corev1.PodSpec, cr *monitoringv2alpha1.
 	// Append or overwrite user-defined environment variables
 	if len(gpuSpec.Envs) > 0 {
 		for _, userEnv := range gpuSpec.Envs {
+			// An explicitly empty remote hostengine address opts the exporter back into
+			// embedded DCGM mode while keeping the hostengine sidecar available.
+			if userEnv.Name == "DCGM_REMOTE_HOSTENGINE_INFO" && userEnv.Value == "" && userEnv.ValueFrom == nil {
+				filtered := envVars[:0]
+				for _, env := range envVars {
+					if env.Name != userEnv.Name {
+						filtered = append(filtered, env)
+					}
+				}
+				envVars = filtered
+				continue
+			}
+
 			found := false
 			for i, env := range envVars {
 				if env.Name == userEnv.Name {

--- a/internal/controller/install_agents_test.go
+++ b/internal/controller/install_agents_test.go
@@ -250,3 +250,44 @@ func TestAddDcgmExporterToNodeAgent_DefaultImagesWithHostEngine(t *testing.T) {
 		t.Fatalf("expected exporter to connect to localhost:5555, got %q", remoteHostEngine)
 	}
 }
+
+func TestAddDcgmExporterToNodeAgent_EmptyRemoteHostEngineUsesEmbeddedMode(t *testing.T) {
+	cr := &monitoringv2alpha1.WhatapAgent{
+		Spec: monitoringv2alpha1.WhatapAgentSpec{
+			Features: monitoringv2alpha1.FeaturesSpec{
+				K8sAgent: monitoringv2alpha1.K8sAgentSpec{
+					GpuMonitoring: monitoringv2alpha1.GpuMonitoringSpec{
+						Enabled: true,
+						Envs: []corev1.EnvVar{
+							{Name: "DCGM_REMOTE_HOSTENGINE_INFO", Value: ""},
+						},
+						HostEngine: &monitoringv2alpha1.DcgmHostEngineSpec{
+							Enabled: true,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	podSpec := corev1.PodSpec{}
+	addDcgmExporterToNodeAgent(&podSpec, cr)
+
+	if len(podSpec.Containers) != 2 {
+		t.Fatalf("expected dcgm-exporter and dcgm-hostengine containers, got %d", len(podSpec.Containers))
+	}
+
+	for _, container := range podSpec.Containers {
+		if container.Name != "dcgm-exporter" {
+			continue
+		}
+		for _, env := range container.Env {
+			if env.Name == "DCGM_REMOTE_HOSTENGINE_INFO" {
+				t.Fatalf("expected empty remote hostengine override to remove the env, got %#v", env)
+			}
+		}
+		return
+	}
+
+	t.Fatal("expected dcgm-exporter container")
+}


### PR DESCRIPTION
## Summary
- interpret explicit empty `DCGM_REMOTE_HOSTENGINE_INFO` as removal, not an empty remote endpoint
- keep the `dcgm-hostengine` sidecar while allowing dcgm-exporter embedded mode
- add regression coverage

## Runtime evidence
- latest 4.6 remote-hostengine mode on dgx-a100 reproduced 184 mixed-MIG subscription errors and was automatically rolled back
- latest embedded 4.6 canary emitted metrics without the driver error
- an empty env previously caused exporter CrashLoop (`Bad parameter passed to function`)

## Verification
- regression test RED before implementation and GREEN after
- controller/webhook/config/API/cmd unit packages PASS.